### PR TITLE
fix issues on 2021 LTS support

### DIFF
--- a/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
+++ b/com.unity.uiwidgets/Runtime/engine/UIWidgetsPanelWrapper.cs
@@ -385,8 +385,9 @@ public partial class UIWidgetsPanelWrapper {
         [DllImport(dllName: NativeBindings.dllName)]
         static extern void UIWidgetsPanel_unregisterTexture(IntPtr ptr, int textureId);
 
-        [DllImport(dllName: NativeBindings.dllName)]
-        static extern void UIWidgetsPanel_markNewFrameAvailable(IntPtr ptr, int textureId);
+        static void UIWidgetsPanel_markNewFrameAvailable(IntPtr ptr, int textureId) {
+            throw new Exception("The native binding of UIWidgetsPanel_markNewFrameAvailable is not implemented yet!!");
+        }
 
 #if UNITY_EDITOR
         [DllImport(dllName: NativeBindings.dllName)]
@@ -487,8 +488,9 @@ public partial class UIWidgetsPanelWrapper {
             }
         }
 
-        [DllImport(dllName: NativeBindings.dllName)]
-        static extern void UIWidgetsPanel_onChar(IntPtr ptr, char c);
+        static void UIWidgetsPanel_onChar(IntPtr ptr, char c) {
+            throw new Exception("The native binding of UIWidgetsPanel_onChar is not implemented yet!!");
+        }
 
         [DllImport(dllName: NativeBindings.dllName)]
         static extern void UIWidgetsPanel_onKey(IntPtr ptr, KeyCode keyCode, bool isKeyDown, int modifier);

--- a/com.unity.uiwidgets/Runtime/ui/compositing.cs
+++ b/com.unity.uiwidgets/Runtime/ui/compositing.cs
@@ -60,9 +60,11 @@ namespace Unity.UIWidgets.ui {
 
         delegate void Scene_toImageCallback(IntPtr callbackHandle, IntPtr result);
 
-        [DllImport(NativeBindings.dllName)]
-        static extern IntPtr Scene_toImage(IntPtr ptr, int width, int height, Scene_toImageCallback callback,
-            IntPtr callbackHandle);
+        static IntPtr Scene_toImage(IntPtr ptr, int width, int height, Scene_toImageCallback callback,
+            IntPtr callbackHandle) {
+                throw new Exception("The native binding of Scene_toImage is not implemented yet!!");
+                return IntPtr.Zero;
+            }
     }
 
     public abstract class _EngineLayerWrapper : EngineLayer {

--- a/com.unity.uiwidgets/Runtime/ui/painting.cs
+++ b/com.unity.uiwidgets/Runtime/ui/painting.cs
@@ -2192,16 +2192,20 @@ namespace Unity.UIWidgets.ui {
         public override void DisposePtr(IntPtr ptr) {
             ImageShader_dispose(ptr);
         }
+        
+        static IntPtr ImageShader_constructor() {
+            throw new Exception("The native binding of ImageShader_constructor is not implemented yet!!");
+            return IntPtr.Zero;
+        }
 
-        [DllImport(NativeBindings.dllName)]
-        static extern IntPtr ImageShader_constructor();
+        static void ImageShader_dispose(IntPtr ptr) {
+            throw new Exception("The native binding of ImageShader_dispose is not implemented yet!!");
+        }
 
-        [DllImport(NativeBindings.dllName)]
-        static extern void ImageShader_dispose(IntPtr ptr);
-
-        [DllImport(NativeBindings.dllName)]
-        static extern unsafe void ImageShader_initWithImage(IntPtr ptr,
-            IntPtr image, int tmx, int tmy, float* matrix4);
+        static unsafe void ImageShader_initWithImage(IntPtr ptr,
+            IntPtr image, int tmx, int tmy, float* matrix4) {
+            throw new Exception("The native binding of ImageShader_initWithImage is not implemented yet!!");
+        }
     }
 
 


### PR DESCRIPTION
mark several unimplemented native binding APIs as unavailable explicitly so that iOS build on 2021 LTS won't argue on these issues.