### PR TITLE
fix cursorheight issue

### DIFF
--- a/com.unity.uiwidgets/Runtime/painting/text_painter.cs
+++ b/com.unity.uiwidgets/Runtime/painting/text_painter.cs
@@ -56,6 +56,7 @@ namespace Unity.UIWidgets.painting {
         TextDirection? _textDirection;
         float _textScaleFactor;
         Paragraph _layoutTemplate;
+        Paragraph _layoutCursorTemplate;
         Paragraph _paragraph;
         bool _needsLayout = true;
         int? _maxLines;
@@ -106,6 +107,7 @@ namespace Unity.UIWidgets.painting {
                 _textScaleFactor = value;
                 markNeedsLayout();
                 _layoutTemplate = null;
+                _layoutCursorTemplate = null;
             }
         }
 
@@ -131,6 +133,7 @@ namespace Unity.UIWidgets.painting {
 
                 if (!Equals(_text == null ? null : _text.style, value == null ? null : value.style)) {
                     _layoutTemplate = null;
+                    _layoutCursorTemplate = null;
                 }
 
                 _text = value;
@@ -155,6 +158,7 @@ namespace Unity.UIWidgets.painting {
                 _textDirection = value;
                 markNeedsLayout();
                 _layoutTemplate = null;
+                _layoutCursorTemplate = null;
             }
         }
 
@@ -449,6 +453,45 @@ namespace Unity.UIWidgets.painting {
                 ellipsis: ellipsis,
                 locale: locale
             );
+        }
+
+        ParagraphStyle _createParagraphStyleWithNoStrutStyle(TextDirection defaultTextDirection = TextDirection.ltr) {
+            D.assert(textDirection != null,
+                () => "TextPainter.textDirection must be set to a non-null value before using the TextPainter.");
+            return _text.style?.getParagraphStyle(
+                textAlign: textAlign,
+                textDirection: textDirection ?? defaultTextDirection,
+                textScaleFactor: textScaleFactor,
+                maxLines: _maxLines,
+                textHeightBehavior: _textHeightBehavior,
+                ellipsis: _ellipsis,
+                locale: _locale
+            ) ?? new ParagraphStyle(
+                textAlign: textAlign,
+                textDirection: textDirection ?? defaultTextDirection,
+                maxLines: maxLines,
+                textHeightBehavior: _textHeightBehavior,
+                ellipsis: ellipsis,
+                locale: locale
+            );
+        }
+
+        public float preferredCursorHeight {
+            get {
+                if (_layoutCursorTemplate == null) {
+                    var builder = new ParagraphBuilder(_createParagraphStyleWithNoStrutStyle(TextDirection.ltr)
+                    ); // direction doesn't matter, text is just a space
+                    if (text != null && text.style != null) {
+                        builder.pushStyle(text.style.getTextStyle(textScaleFactor: textScaleFactor));
+                    }
+
+                    builder.addText(" ");
+                    _layoutCursorTemplate = builder.build();
+                    _layoutCursorTemplate.layout(new ParagraphConstraints(float.PositiveInfinity));
+                }
+
+                return _layoutCursorTemplate.height();
+            }
         }
 
         public float preferredLineHeight {

--- a/com.unity.uiwidgets/Runtime/rendering/editable.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/editable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Unity.UIWidgets.async;
 using Unity.UIWidgets.foundation;
 using Unity.UIWidgets.gestures;
@@ -1596,7 +1597,9 @@ namespace Unity.UIWidgets.rendering {
 
             //if there is no contents in this editable yet, we use the _getCaretPrototypeForEmptyLine API to fetch the proper caret height
             var currentCaretPrototype = _caretPrototype;
-            if (text.text == "") {
+            var content = new StringBuilder();
+            text.computeToPlainText(content, false, false);
+            if (string.IsNullOrEmpty(content.ToString())) {
                 currentCaretPrototype = _getCaretPrototypeForEmptyLine;
             }
             
@@ -1606,7 +1609,6 @@ namespace Unity.UIWidgets.rendering {
             if (_cursorOffset != null) {
                 caretRect = caretRect.shift(_cursorOffset);
             }
-
             float? caretHeight = _textPainter.getFullHeightForCaret(textPosition, currentCaretPrototype);
             if (caretHeight != null) {
                 switch (Application.platform) {

--- a/com.unity.uiwidgets/Runtime/rendering/editable.cs
+++ b/com.unity.uiwidgets/Runtime/rendering/editable.cs
@@ -1553,7 +1553,7 @@ namespace Unity.UIWidgets.rendering {
             get {
                 switch (Application.platform) {
                     case RuntimePlatform.IPhonePlayer:
-                        return Rect.fromLTWH(0.0f, 0.0f, cursorWidth,
+                        return Rect.fromLTWH(0.0f, (preferredLineHeight - preferredCursorHeight) / 2, cursorWidth,
                             preferredCursorHeight + 2.0f);
                     default:
                         return Rect.fromLTWH(0.0f, (preferredLineHeight - preferredCursorHeight) / 2, cursorWidth,


### PR DESCRIPTION
In this PR we aims to fix the issue reported in #24 

Similar issues are also reported in flutter like https://github.com/flutter/flutter/issues/92080

We first locate the root cause in the calculation of the preferredLineHeight of an editable text, in which the line height is estimated by as `text height + 2 * leadings height` when the `strutStyle.leading` is not null. Since this height is then used as the default cursor height when no text is in the text field, the cursor height will become inappropriate and different than the real `text height`.

To fix this issue, we just introduce a new code path where the cursor height is calculated in a different way when the text field contains no content.

By the way we also introduce another bug fix reported in flutter here https://github.com/flutter/flutter/issues/31661